### PR TITLE
fix: ensure math for extended sub/superscript

### DIFF
--- a/laas.el
+++ b/laas.el
@@ -84,6 +84,7 @@ insert a new subscript (e.g a -> a_1)."
         ((and (or (= (char-before (1- (point))) ?_)
                   (= (char-before (1- (point))) ?^))
               (/= (char-before) ?{))
+              (laas-mathp)
          'extended-sub)
         ((and
           ;; Before is some indexable char


### PR DESCRIPTION
Hi @tecosaur,

While using your package I had the annoying behaviour when entering citations manually (e.g `\cite{tec_laas_20}` would automatically expands into `\cite{tec_laas_{20}}`. 

Fortunately, this was a one-line fix :) 

I don't know if you accept PR on github, or if you prefer it to happen on https://git.tecosaur.net/tec/LaTeX-auto-activating-snippets


